### PR TITLE
Fix loading of net6.0 6.0.x

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+# 1.2.1
+* Support for net6.0 version 6.0.1
+
 # 1.1.0
 * Support for net 6.0
 

--- a/src/fasmi/Compilation.fs
+++ b/src/fasmi/Compilation.fs
@@ -40,7 +40,13 @@ let compile (path: string) (asmPath: string) =
     let net50Path = 
         let  runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
 #if NET6_0
-        IO.Path.GetFullPath(runtimeDir </> "../../../packs/Microsoft.NETCore.App.Ref/6.0.0/ref/net6.0/")
+        
+        let packDir = 
+            IO.Directory.GetDirectories(runtimeDir </> "../../../packs/Microsoft.NETCore.App.Ref/", "6.0.*")
+            |> Seq.max
+        IO.Path.GetFullPath(packDir </> "ref/net6.0")
+
+        //IO.Path.GetFullPath(runtimeDir </> "../../../packs/Microsoft.NETCore.App.Ref/6.0.0/ref/net6.0/")
 #else
         IO.Path.GetFullPath(runtimeDir </> "../../../packs/Microsoft.NETCore.App.Ref/5.0.0/ref/net5.0/")
 #endif

--- a/src/fasmi/fasmi.fsproj
+++ b/src/fasmi/fasmi.fsproj
@@ -17,7 +17,7 @@
     <PackageProjectUrl>https://github.com/d-edge/fasmi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/d-edge/fasmi</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FileSystem.fs" />


### PR DESCRIPTION
Once upgraded to version 6.0.1, the loading of reference assemblies broke.

This PR is fixing this by looking for the highest 6.0.* version.